### PR TITLE
Not finding a Pivot for a variable is not cause for crashing

### DIFF
--- a/reluplex/Reluplex.h
+++ b/reluplex/Reluplex.h
@@ -2373,7 +2373,7 @@ public:
 
         unsigned pivotCandidate;
         if ( !findPivotCandidate( var, increase, pivotCandidate, false ) ){
-            printf("Can't findPivotCandidate for a variable\n");
+            log("Can't findPivotCandidate for a variable\n");
             return true;
         }
 

--- a/reluplex/Reluplex.h
+++ b/reluplex/Reluplex.h
@@ -2372,8 +2372,10 @@ public:
             ( _upperBounds[var].getBound() - _assignment[var] );
 
         unsigned pivotCandidate;
-        if ( !findPivotCandidate( var, increase, pivotCandidate, false ) )
-            return false;
+        if ( !findPivotCandidate( var, increase, pivotCandidate, false ) ){
+            printf("Can't findPivotCandidate for a variable\n");
+            return true;
+        }
 
         log( Stringf( "\nPivotAndUpdate: <%s, %5.2lf, %s>\n",
                       toName( var ).ascii(),


### PR DESCRIPTION
We don't want to fail if an aux var can't be eliminated because no pivot for it can be found.
This tends to happen when some of the layers have extremely sparse weights.