### PR TITLE
Bug fix

### DIFF
--- a/reluplex/Reluplex.h
+++ b/reluplex/Reluplex.h
@@ -3648,7 +3648,10 @@ public:
                 while ( ( basic != _basicVariables.end() ) && !needToRestart )
                 {
                     needToRestart = tightenBoundsOnRow( *basic, numLearnedBounds );
-                    ++basic;
+                    if ( !needToRestart )
+                    {
+                        ++basic;
+                    }
                 }
 
                 if ( !needToRestart )


### PR DESCRIPTION
When needToRestart is true, the set _basicVariables gets modified during a pivot, so the set iterator should not be incremented. Incrementing the iterator causes a seg fault on Mac.